### PR TITLE
Extra convenience options for no caption and no thumbnail

### DIFF
--- a/telegram_upload/client.py
+++ b/telegram_upload/client.py
@@ -60,16 +60,17 @@ class Client(TelegramClient):
                              first_name=first_name, last_name=last_name, max_attempts=max_attempts)
 
     def send_files(self, entity, files, delete_on_success=False, print_file_id=False,
-                   force_file=False, forward=(), caption=None):
+                   force_file=False, forward=(), caption=None, no_thumbnail=False):
         for file in files:
             file_size = os.path.getsize(file)
             progress, bar = get_progress_bar('Uploading', os.path.basename(file), file_size)
             name = '.'.join(os.path.basename(file).split('.')[:-1])
             thumb = None
-            try:
-                thumb = get_file_thumb(file)
-            except ThumbError as e:
-                click.echo('{}'.format(e), err=True)
+            if not no_thumbnail:
+                try:
+                    thumb = get_file_thumb(file)
+                except ThumbError as e:
+                    click.echo('{}'.format(e), err=True)
             file_caption = truncate(caption or name, CAPTION_MAX_LENGTH)
             try:
                 if force_file:

--- a/telegram_upload/client.py
+++ b/telegram_upload/client.py
@@ -71,7 +71,7 @@ class Client(TelegramClient):
                     thumb = get_file_thumb(file)
                 except ThumbError as e:
                     click.echo('{}'.format(e), err=True)
-            file_caption = truncate(caption or name, CAPTION_MAX_LENGTH)
+            file_caption = truncate(caption if caption is not None else name, CAPTION_MAX_LENGTH)
             try:
                 if force_file:
                     attributes = [DocumentAttributeFilename(file)]

--- a/telegram_upload/client.py
+++ b/telegram_upload/client.py
@@ -62,9 +62,10 @@ class Client(TelegramClient):
     def send_files(self, entity, files, delete_on_success=False, print_file_id=False,
                    force_file=False, forward=(), caption=None, no_thumbnail=False):
         for file in files:
+            file_name = os.path.basename(file)
             file_size = os.path.getsize(file)
-            progress, bar = get_progress_bar('Uploading', os.path.basename(file), file_size)
-            name = '.'.join(os.path.basename(file).split('.')[:-1])
+            progress, bar = get_progress_bar('Uploading', file_name, file_size)
+            name = '.'.join(file_name.split('.')[:-1])
             thumb = None
             if not no_thumbnail:
                 try:
@@ -74,7 +75,7 @@ class Client(TelegramClient):
             file_caption = truncate(caption if caption is not None else name, CAPTION_MAX_LENGTH)
             try:
                 if force_file:
-                    attributes = [DocumentAttributeFilename(file)]
+                    attributes = [DocumentAttributeFilename(file_name)]
                 else:
                     attributes = get_file_attributes(file)
                 try:

--- a/telegram_upload/client.py
+++ b/telegram_upload/client.py
@@ -94,7 +94,7 @@ class Client(TelegramClient):
             if print_file_id:
                 click.echo('Uploaded successfully "{}" (file_id {})'.format(file, pack_bot_file_id(message.media)))
             if delete_on_success:
-                click.echo('Deleting {}'.format(file))
+                click.echo('Deleting "{}"'.format(file))
                 os.remove(file)
             self.forward_to(message, forward)
 

--- a/telegram_upload/client.py
+++ b/telegram_upload/client.py
@@ -86,8 +86,6 @@ class Client(TelegramClient):
                                 message.media.document.size, file_size))
                 finally:
                     bar.render_finish()
-            except Exception:
-                raise
             finally:
                 if thumb:
                     os.remove(thumb)

--- a/telegram_upload/management.py
+++ b/telegram_upload/management.py
@@ -28,7 +28,10 @@ DIRECTORY_MODES = {
 @click.option('--directories', default='fail', type=click.Choice(list(DIRECTORY_MODES.keys())),
               help='Action to take with the folders. By default an error is caused.')
 @click.option('--caption', type=str, help='Change file description. By default the file name.')
-def upload(files, to, config, delete_on_success, print_file_id, force_file, forward, caption, directories):
+@click.option('--no-thumbnail', is_flag=True, help='Disable thumbnail generation. For some known file formats, '
+                                                   'Telegram may still generate a thumbnail or show a preview.')
+def upload(files, to, config, delete_on_success, print_file_id, force_file, forward, caption, directories,
+           no_thumbnail):
     """Upload one or more files to Telegram using your personal account.
     The maximum file size is 1.5 GiB and by default they will be saved in
     your saved messages.
@@ -39,7 +42,7 @@ def upload(files, to, config, delete_on_success, print_file_id, force_file, forw
     if directories == 'fail':
         # Validate now
         files = list(files)
-    client.send_files(to, files, delete_on_success, print_file_id, force_file, forward, caption)
+    client.send_files(to, files, delete_on_success, print_file_id, force_file, forward, caption, no_thumbnail)
 
 
 @click.command()


### PR DESCRIPTION
- `--no-thumbnail` option has been added.
- `--caption ""` is now respected. Previously, it would fallback to the file name (without extension), even if the user had explicitly specified an empty string.
- With `--force-file`, the file path was wrongly being used, instead of the file name.