### PR TITLE
expand CAPTION_MAX_LENGTH to 2000 chars

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,8 +36,9 @@ telegram-upload
 Telegram-upload uses your personal Telegram account to upload and download files up to 2GiB (bots are limited to 50
 MiB). Turn Telegram into your personal cloud!
 
-## It supports up to 2000 chars in file caption
-
+###############
+It supports up to 2000 chars in file caption
+###############
 
 To **install telegram-upload**, run this command in your terminal:
 

--- a/README.rst
+++ b/README.rst
@@ -36,6 +36,8 @@ telegram-upload
 Telegram-upload uses your personal Telegram account to upload and download files up to 2GiB (bots are limited to 50
 MiB). Turn Telegram into your personal cloud!
 
+## It supports up to 2000 chars in file caption
+
 
 To **install telegram-upload**, run this command in your terminal:
 

--- a/telegram_upload/files.py
+++ b/telegram_upload/files.py
@@ -18,7 +18,7 @@ mimetypes.init()
 
 
 MAX_FILE_SIZE = 2097152000
-CAPTION_MAX_LENGTH = 200
+CAPTION_MAX_LENGTH = 2000
 
 
 def is_valid_file(file, error_logger=None):

--- a/telegram_upload/files.py
+++ b/telegram_upload/files.py
@@ -18,7 +18,7 @@ mimetypes.init()
 
 
 MAX_FILE_SIZE = 2097152000
-CAPTION_MAX_LENGTH = 2000
+CAPTION_MAX_LENGTH = 1024
 
 
 def is_valid_file(file, error_logger=None):


### PR DESCRIPTION
Telegram supports up to 2000 chars in file caption