### PR TITLE
Give More control over caption

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,6 +94,7 @@ Features
 * Download files.
 * Add video thumbs.
 * Delete local or remote file on success.
+* File name, path in caption
 
 Docker
 ======

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -117,3 +117,12 @@ An example without credentials::
 An example with credentials::
 
     socks4://user:pass@proxy.my.site:1080
+
+
+Upload with directory structure
+===============================
+You can use caption variables to upload entire directory with path as cption.
+
+To upload all files and directories under current directory with path caption::
+
+    $ telegram-upload . --directories recursive --caption "{path}"

--- a/telegram_upload/files.py
+++ b/telegram_upload/files.py
@@ -176,8 +176,11 @@ class File(FileIO):
 
     @property
     def file_caption(self) -> str:
+        path = self.path
+        if path.startswith("./"):
+            path = path[2:]
         self.file_info = {
-            "path": self.path.removeprefix("./"),
+            "path": path,
             "file_name": self.file_name,
             "short_name": self.short_name,
         }

--- a/telegram_upload/files.py
+++ b/telegram_upload/files.py
@@ -177,13 +177,12 @@ class File(FileIO):
     @property
     def file_caption(self) -> str:
         self.file_info = {
+            "path": self.path.removeprefix("./"),
             "file_name": self.file_name,
-            "path": self.path,
             "short_name": self.short_name,
-            "file_size": self.file_size,
         }
         if self._caption is not None:
-            self.__caption = self._caption % self.file_info
+            self.__caption = self._caption.format_map(self.file_info)
         return truncate(
             self.__caption if self._caption is not None else self.short_name,
             CAPTION_MAX_LENGTH,

--- a/telegram_upload/files.py
+++ b/telegram_upload/files.py
@@ -177,7 +177,7 @@ class File(FileIO):
     @property
     def file_caption(self) -> str:
         path = self.path
-        if path.startswith("./"):
+        if path.startswith(("./", ".\\")):
             path = path[2:]
         self.file_info = {
             "path": path,

--- a/telegram_upload/files.py
+++ b/telegram_upload/files.py
@@ -102,7 +102,10 @@ class RecursiveFiles(FilesBase):
             if os.path.isdir(file):
                 yield from map(
                     lambda file: file.path,
-                    filter(lambda x: not x.is_dir(), scantree(file, True)),
+                    filter(
+                        lambda x: not x.is_dir() and x.stat().st_size,
+                        scantree(file, True),
+                    ),
                 )
             else:
                 yield file

--- a/telegram_upload/management.py
+++ b/telegram_upload/management.py
@@ -146,8 +146,9 @@ def upload(files, to, config, delete_on_success, print_file_id, force_file, forw
     elif to is None:
         to = 'me'
     try:
+        # For chat id
         to = int(to)
-    except:
+    except ValueError:
         pass
     files = filter(lambda file: is_valid_file(file, lambda message: click.echo(message, err=True)), files)
     files = DIRECTORY_MODES[directories](files)

--- a/telegram_upload/management.py
+++ b/telegram_upload/management.py
@@ -114,7 +114,8 @@ class MutuallyExclusiveOption(click.Option):
 @click.option('--large-files', default='fail', type=click.Choice(list(LARGE_FILE_MODES.keys())),
               help='Defines how to process large files unsupported for Telegram. By default large files are not '
                    'accepted and will raise an error.')
-@click.option('--caption', type=str, help='Change file description. By default the file name.')
+@click.option('--caption', type=str, help='Change file description. By default the short name. '
+                                          'Use variables {path}, {short_name}, {file_name} in caption.')
 @click.option('--no-thumbnail', is_flag=True, cls=MutuallyExclusiveOption, mutually_exclusive=["thumbnail_file"],
               help='Disable thumbnail generation. For some known file formats, Telegram may still generate a '
                    'thumbnail or show a preview.')

--- a/telegram_upload/management.py
+++ b/telegram_upload/management.py
@@ -145,6 +145,10 @@ def upload(files, to, config, delete_on_success, print_file_id, force_file, forw
         to = async_to_sync(interactive_select_dialog(client))
     elif to is None:
         to = 'me'
+    try:
+        to = int(to)
+    except:
+        pass
     files = filter(lambda file: is_valid_file(file, lambda message: click.echo(message, err=True)), files)
     files = DIRECTORY_MODES[directories](files)
     if directories == 'fail':

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -44,8 +44,12 @@ class TestRecursiveFiles(unittest.TestCase):
         directory.is_dir.side_effect = [True, False]
         file = Mock()
         file.is_dir.return_value = False
+        file.stat.return_value.st_size = 1
         side_effect = [file] * 3
-        m2.return_value = side_effect
+        empty_file = Mock()
+        empty_file.is_dir.return_value = False
+        empty_file.stat.return_value.st_size = 0
+        m2.return_value = side_effect + [empty_file]
         self.assertEqual(list(RecursiveFiles(["foo"])), [x.path for x in side_effect])
 
 

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -3,36 +3,42 @@ import unittest
 from unittest.mock import patch, Mock
 
 from telegram_upload.exceptions import TelegramInvalidFile
-from telegram_upload.files import get_file_attributes, RecursiveFiles, NoDirectoriesFiles, MAX_FILE_SIZE, \
-    NoLargeFiles, SplitFiles, SplitFile
+from telegram_upload.files import (
+    get_file_attributes,
+    RecursiveFiles,
+    NoDirectoriesFiles,
+    MAX_FILE_SIZE,
+    NoLargeFiles,
+    SplitFiles,
+    SplitFile,
+    File,
+)
 
 
 class TestGetFileAttributes(unittest.TestCase):
     def test_not_video(self):
-        self.assertEqual(get_file_attributes('foo.png'), [])
+        self.assertEqual(get_file_attributes("foo.png"), [])
 
-    @patch('telegram_upload.files.video_metadata')
+    @patch("telegram_upload.files.video_metadata")
     def test_video(self, m_video_metadata):
         m_video_metadata.return_value.has.return_value = True
         duration = Mock()
         duration.seconds = 1000
-        m_video_metadata.return_value.get.side_effect = [
-            duration, 1920, 1080
-        ]
-        attrs = get_file_attributes('foo.mp4')
+        m_video_metadata.return_value.get.side_effect = [duration, 1920, 1080]
+        attrs = get_file_attributes("foo.mp4")
         self.assertEqual(attrs[0].w, 1920)
         self.assertEqual(attrs[0].h, 1080)
         self.assertEqual(attrs[0].duration, 1000)
 
 
 class TestRecursiveFiles(unittest.TestCase):
-    @patch('telegram_upload.files.scantree', return_value=[])
-    @patch('telegram_upload.files.os.path.isdir', return_value=False)
+    @patch("telegram_upload.files.scantree", return_value=[])
+    @patch("telegram_upload.files.os.path.isdir", return_value=False)
     def test_one_file(self, m1, m2):
-        self.assertEqual(list(RecursiveFiles(['foo'])), ['foo'])
+        self.assertEqual(list(RecursiveFiles(["foo"])), ["foo"])
 
-    @patch('telegram_upload.files.scantree')
-    @patch('telegram_upload.files.os.path.isdir', return_value=True)
+    @patch("telegram_upload.files.scantree")
+    @patch("telegram_upload.files.os.path.isdir", return_value=True)
     def test_directory(self, m1, m2):
         directory = Mock()
         directory.is_dir.side_effect = [True, False]
@@ -40,60 +46,75 @@ class TestRecursiveFiles(unittest.TestCase):
         file.is_dir.return_value = False
         side_effect = [file] * 3
         m2.return_value = side_effect
-        self.assertEqual(list(RecursiveFiles(['foo'])), [x.path for x in side_effect])
+        self.assertEqual(list(RecursiveFiles(["foo"])), [x.path for x in side_effect])
 
 
 class TestNoDirectoriesFiles(unittest.TestCase):
-    @patch('telegram_upload.files.scantree', return_value=[])
-    @patch('telegram_upload.files.os.path.isdir', return_value=False)
+    @patch("telegram_upload.files.scantree", return_value=[])
+    @patch("telegram_upload.files.os.path.isdir", return_value=False)
     def test_one_file(self, m1, m2):
-        self.assertEqual(list(NoDirectoriesFiles(['foo'])), ['foo'])
+        self.assertEqual(list(NoDirectoriesFiles(["foo"])), ["foo"])
 
-    @patch('telegram_upload.files.os.path.isdir', return_value=True)
+    @patch("telegram_upload.files.os.path.isdir", return_value=True)
     def test_directory(self, m):
         with self.assertRaises(TelegramInvalidFile):
-            next(NoDirectoriesFiles(['foo']))
+            next(NoDirectoriesFiles(["foo"]))
 
 
 class TestNoLargeFiles(unittest.TestCase):
-    @patch('telegram_upload.files.os.path.getsize', return_value=MAX_FILE_SIZE - 1)
-    @patch('telegram_upload.files.File')
+    @patch("telegram_upload.files.os.path.getsize", return_value=MAX_FILE_SIZE - 1)
+    @patch("telegram_upload.files.File")
     def test_small_file(self, m1, m2):
-        self.assertEqual(len(list(NoLargeFiles(['foo']))), 1)
+        self.assertEqual(len(list(NoLargeFiles(["foo"]))), 1)
 
-    @patch('telegram_upload.files.os.path.getsize', return_value=MAX_FILE_SIZE + 1)
+    @patch("telegram_upload.files.os.path.getsize", return_value=MAX_FILE_SIZE + 1)
     def test_big_file(self, m):
         with self.assertRaises(TelegramInvalidFile):
-            next(NoLargeFiles(['foo']))
+            next(NoLargeFiles(["foo"]))
 
 
 class TestSplitFile(unittest.TestCase):
     def test_file(self):
         this_file = os.path.abspath(__file__)
         size = os.path.getsize(this_file)
-        file0 = SplitFile(this_file, size - 100, 'test.py.00')
-        file1 = SplitFile(this_file, 100, 'test.py.01')
+        file0 = SplitFile(this_file, size - 100, "test.py.00")
+        file1 = SplitFile(this_file, 100, "test.py.01")
         file1.seek(size - 100, split_seek=True)
-        with open(this_file, 'rb') as f:
+        with open(this_file, "rb") as f:
             content = f.read()
         self.assertEqual(file0.readall() + file1.readall(), content)
-        self.assertEqual(file0.file_name, 'test.py.00')
+        self.assertEqual(file0.file_name, "test.py.00")
         self.assertEqual(file1.file_size, 100)
         file0.close()
         file1.close()
 
 
 class TestSplitFiles(unittest.TestCase):
-    @patch('telegram_upload.files.os.path.getsize', return_value=MAX_FILE_SIZE - 1)
-    @patch('telegram_upload.files.File')
+    @patch("telegram_upload.files.os.path.getsize", return_value=MAX_FILE_SIZE - 1)
+    @patch("telegram_upload.files.File")
     def test_small_file(self, m1, m2):
-        self.assertEqual(len(list(SplitFiles(['foo']))), 1)
+        self.assertEqual(len(list(SplitFiles(["foo"]))), 1)
 
-    @patch('telegram_upload.files.os.path.getsize', return_value=MAX_FILE_SIZE + 1000)
-    @patch('telegram_upload.files.SplitFile.__init__', return_value=None)
-    @patch('telegram_upload.files.SplitFile.seek')
+    @patch("telegram_upload.files.os.path.getsize", return_value=MAX_FILE_SIZE + 1000)
+    @patch("telegram_upload.files.SplitFile.__init__", return_value=None)
+    @patch("telegram_upload.files.SplitFile.seek")
     def test_big_file(self, m_getsize, m_init, m_seek):
-        files = list(SplitFiles(['foo']))
+        files = list(SplitFiles(["foo"]))
         self.assertEqual(len(files), 2)
-        self.assertEqual(m_init.call_args_list[0][0], ('foo', MAX_FILE_SIZE, 'foo.00'))
-        self.assertEqual(m_init.call_args_list[1][0], ('foo', 1000, 'foo.01'))
+        self.assertEqual(m_init.call_args_list[0][0], ("foo", MAX_FILE_SIZE, "foo.00"))
+        self.assertEqual(m_init.call_args_list[1][0], ("foo", 1000, "foo.01"))
+
+
+class TestFile(unittest.TestCase):
+    def test_file_caption(self):
+        def __init__(self, path, caption):
+            self.path = path
+            self._caption = caption
+
+        with patch.object(File, "__init__", __init__):
+            file0 = File("./d/abc.xyz", "{path}")
+            file1 = File("./d/abc.xyz", caption="{file_name}")
+            file2 = File("./d/abc.xyz", caption="{short_name}")
+            self.assertEqual(file0.file_caption, "d/abc.xyz")
+            self.assertEqual(file1.file_caption, "abc.xyz")
+            self.assertEqual(file2.file_caption, "abc")


### PR DESCRIPTION
Use file info in caption
e.g.
1. --caption "%(path)s"
2. --caption "Name: %(short_name)s Size: %(file_size)s"

Probably closes #115 :- caption can be set to path(e.g. 1) to mimic folder structure.
