### PR TITLE
fix: enable entity from existing entities list

### DIFF
--- a/telegram_upload/client.py
+++ b/telegram_upload/client.py
@@ -113,6 +113,11 @@ class Client(TelegramClient):
             raise InvalidApiFileError(self.config_file)
 
     async def _send_album_media(self, entity, media):
+        self.get_dialogs()
+        try:
+            entity = int(entity)
+        except:
+            pass
         entity = await self.get_input_entity(entity)
         request = functions.messages.SendMultiMediaRequest(
             entity, reply_to_msg_id=None, multi_media=media,
@@ -130,6 +135,11 @@ class Client(TelegramClient):
             async_to_sync(self._send_album_media(entity, media))
 
     def _send_file_message(self, entity, file, thumb, progress):
+        self.get_dialogs()
+        try:
+            entity = int(entity)
+        except:
+            pass
         message = self.send_file(entity, file, thumb=thumb,
                                  file_size=file.file_size if isinstance(file, File) else None,
                                  caption=file.file_caption, force_document=file.force_file,
@@ -141,6 +151,11 @@ class Client(TelegramClient):
         return message
 
     async def _send_media(self, entity, file: File, progress):
+        self.get_dialogs()
+        try:
+            entity = int(entity)
+        except:
+            pass
         entity = await self.get_input_entity(entity)
         supports_streaming = False  # TODO
         fh, fm, _ = await self._file_to_media(

--- a/telegram_upload/client.py
+++ b/telegram_upload/client.py
@@ -151,7 +151,7 @@ class Client(TelegramClient):
         return message
 
     async def _send_media(self, entity, file: File, progress):
-        self.get_dialogs()
+        await self.get_dialogs()
         try:
             entity = int(entity)
         except:

--- a/telegram_upload/client.py
+++ b/telegram_upload/client.py
@@ -113,7 +113,7 @@ class Client(TelegramClient):
             raise InvalidApiFileError(self.config_file)
 
     async def _send_album_media(self, entity, media):
-        self.get_dialogs()
+        await self.get_dialogs()
         try:
             entity = int(entity)
         except:


### PR DESCRIPTION
fix #163 #118

As explained in the note here:
https://docs.telethon.dev/en/stable/concepts/entities.html?highlight=client.get_dialogs()#entities

> To “encounter” an ID, you would have to “find it” like you would in the normal app. If the peer is in your dialogs, you would need to client.get_dialogs(). If the peer is someone in a group, you would similarly client.get_participants(group).