### PR TITLE
Added auth with bot token and support for ids for --to

### DIFF
--- a/telegram_upload/client.py
+++ b/telegram_upload/client.py
@@ -107,17 +107,12 @@ class Client(TelegramClient):
             *,
             force_sms=False, code_callback=None,
             first_name='New User', last_name='', max_attempts=3):
-        mode = click.prompt('Choose mode: User [u] or Bot [b]')
-        if mode == 'u':
-            phone = click.prompt('Please enter your phone', type=phone_match)
-            password = getpass.getpass('Please enter your password: ')
-        elif mode == 'b':
-            bot_token = click.prompt('Please enter your bot token: ')
-        else:
-            raise KeyError('Unknown mode')
+        with open(self.config_file) as f:
+            config = json.load(f)
         try:
-            return super().start(phone=phone, password=password, bot_token=bot_token, force_sms=force_sms,
-                                 first_name=first_name, last_name=last_name, max_attempts=max_attempts)
+            return super().start(phone=config.get('phone', None), password=config.get('password', None),
+                                 bot_token=config.get('bot_token', None), force_sms=force_sms, first_name=first_name,
+                                 last_name=last_name, max_attempts=max_attempts)
         except ApiIdInvalidError:
             raise InvalidApiFileError(self.config_file)
 

--- a/telegram_upload/client.py
+++ b/telegram_upload/client.py
@@ -101,10 +101,10 @@ class Client(TelegramClient):
 
     def start(
             self,
-            phone=lambda: click.prompt('Please enter your phone', type=phone_match),
-            password=lambda: getpass.getpass('Please enter your password: '),
+            phone=None,
+            password=None,
             *,
-            bot_token=None, force_sms=False, code_callback=None,
+            bot_token=lambda: getpass.getpass('Please enter your bot token'), force_sms=False, code_callback=None,
             first_name='New User', last_name='', max_attempts=3):
         try:
             return super().start(phone=phone, password=password, bot_token=bot_token, force_sms=force_sms,

--- a/telegram_upload/client.py
+++ b/telegram_upload/client.py
@@ -101,11 +101,20 @@ class Client(TelegramClient):
 
     def start(
             self,
+            bot_token=None,
             phone=None,
             password=None,
             *,
-            bot_token=lambda: getpass.getpass('Please enter your bot token'), force_sms=False, code_callback=None,
+            force_sms=False, code_callback=None,
             first_name='New User', last_name='', max_attempts=3):
+        mode = click.prompt('Choose mode: User [u] or Bot [b]')
+        if mode == 'u':
+            phone = click.prompt('Please enter your phone', type=phone_match)
+            password = getpass.getpass('Please enter your password: ')
+        elif mode == 'b':
+            bot_token = click.prompt('Please enter your bot token: ')
+        else:
+            raise KeyError('Unknown mode')
         try:
             return super().start(phone=phone, password=password, bot_token=bot_token, force_sms=force_sms,
                                  first_name=first_name, last_name=last_name, max_attempts=max_attempts)

--- a/telegram_upload/config.py
+++ b/telegram_upload/config.py
@@ -1,5 +1,7 @@
+import getpass
 import json
 import os
+import re
 
 import click
 
@@ -8,13 +10,34 @@ CONFIG_FILE = os.path.expanduser('{}/telegram-upload.json'.format(CONFIG_DIRECTO
 SESSION_FILE = os.path.expanduser('{}/telegram-upload'.format(CONFIG_DIRECTORY))
 
 
+def phone_match(value):
+    match = re.match(r'\+?[0-9.()\[\] \-]+', value)
+    if match is None:
+        raise ValueError('{} is not a valid phone'.format(value))
+    return value
+
+
 def prompt_config(config_file):
     os.makedirs(os.path.dirname(config_file), exist_ok=True)
+    config_data = {}
     click.echo('Go to https://my.telegram.org and create a App in API development tools')
     api_id = click.prompt('Please Enter api_id', type=int)
+    config_data['api_id'] = api_id
     api_hash = click.prompt('Now enter api_hash')
+    config_data['api_hash'] = api_hash
+    mode = click.prompt('Choose mode: User [u] or Bot [b]')
+    if mode == 'u':
+        phone = click.prompt('Please enter your phone', type=phone_match)
+        config_data['phone'] = phone
+        password = getpass.getpass('Please enter your password: ')
+        config_data['password'] = password
+    elif mode == 'b':
+        bot_token = click.prompt('Please enter your bot token: ')
+        config_data['bot_token'] = bot_token
+    else:
+        raise KeyError('Unknown mode')
     with open(config_file, 'w') as f:
-        json.dump({'api_id': api_id, 'api_hash': api_hash}, f)
+        json.dump(config_data, f)
     return config_file
 
 

--- a/telegram_upload/management.py
+++ b/telegram_upload/management.py
@@ -150,6 +150,13 @@ def upload(files, to, config, delete_on_success, print_file_id, force_file, forw
         to = async_to_sync(interactive_select_dialog(client))
     elif to is None:
         to = 'me'
+    elif to is not None:
+        try:
+            _ = int(to)
+        except:
+            pass
+        else:
+            to = int(to)
     files = filter(lambda file: is_valid_file(file, lambda message: click.echo(message, err=True)), files)
     files = DIRECTORY_MODES[directories](files)
     if directories == 'fail':


### PR DESCRIPTION
Simple patch to allow using bot tokens to auth as a bot and use integer ids instead of only strings