### PR TITLE
Small patch CLI list of items (fixes ignoring some files; also corrects limit, as expected, so then PAGE_SIZE will be *size*) 

### DIFF
--- a/telegram_upload/utils.py
+++ b/telegram_upload/utils.py
@@ -52,10 +52,10 @@ async def aislice(iterator, limit):
     items = []
     i = 0
     async for value in iterator:
-        if i > limit:
-            break
-        i += 1
         items.append(value)
+        i += 1
+        if i >= limit:
+            break
     return items
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,9 @@
 import unittest
 from unittest.mock import patch, Mock
 
-from telegram_upload.utils import sizeof_fmt, scantree
+from telegram_upload.utils import sizeof_fmt, scantree, aislice
+
+import asyncio # for TestAISlice's test_general
 
 
 class TestSizeOfFmt(unittest.TestCase):
@@ -36,3 +38,30 @@ class TestScanTree(unittest.TestCase):
         side_effect = [[directory], [file] * 3]
         m.side_effect = side_effect
         self.assertEqual(list(scantree('foo')), side_effect[-1])
+
+class TestAISlice(unittest.TestCase):
+    def test_general(self):
+        class asyncFromList:
+            def __init__(self, rawlist):
+                self.rawidx = -1
+                self.rawlist = rawlist.copy()
+            def __aiter__(self):
+                return self
+            async def __anext__(self):
+                await asyncio.sleep(0)
+                self.rawidx += 1
+                if self.rawidx >= len(self.rawlist):
+                    raise StopAsyncIteration
+                return self.rawlist[self.rawidx]
+        async def async_collect_all_files(it, pagesize):
+            ret = []
+            while True:
+                aislice_res = await aislice(it, pagesize)
+                if len(aislice_res) == 0: break
+                self.assertLessEqual(len(aislice_res), pagesize, "limit returns more than asked")
+                ret.extend(aislice_res)
+            return ret
+        pagesize = 10
+        files = [ str(i) for i in range(51) ]
+        gotfiles = asyncio.get_event_loop().run_until_complete(async_collect_all_files(asyncFromList(files), pagesize))
+        self.assertEqual(gotfiles, files, "got different set of values")


### PR DESCRIPTION
Fixes ignoring files in CLI list (every file at limit+2 index), also now it returns proper count of items (as expected?) (PAGE_SIZE items, not PAGE_SIZE+1)