### PR TITLE
Remove distutils module

### DIFF
--- a/telegram_upload/client/telegram_manager_client.py
+++ b/telegram_upload/client/telegram_manager_client.py
@@ -3,7 +3,6 @@ import json
 import os
 import re
 import sys
-from distutils.version import StrictVersion
 from typing import Union
 from urllib.parse import urlparse
 
@@ -18,7 +17,7 @@ from telegram_upload.client.telegram_upload_client import TelegramUploadClient
 from telegram_upload.config import SESSION_FILE
 from telegram_upload.exceptions import TelegramProxyError, InvalidApiFileError
 
-if StrictVersion(telethon_version) >= StrictVersion('1.0'):
+if int(telethon_version[0]) >= 1:
     import telethon.sync  # noqa
 
 


### PR DESCRIPTION
Fix telegram-upload crashing on python 3.13 by removing any usage of distutils.

Traceback:
```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "C:\Users\usert\.local\bin\telegram-upload.exe\__main__.py", line 4, in <module>
    from telegram_upload.management import upload_cli
  File "C:\Users\usert\pipx\venvs\telegram-upload\Lib\site-packages\telegram_upload\management.py", line 10, in <module>
    from telegram_upload.client import TelegramManagerClient, get_message_file_attribute
  File "C:\Users\usert\pipx\venvs\telegram-upload\Lib\site-packages\telegram_upload\client\__init__.py", line 1, in <module>
    from telegram_upload.client.telegram_manager_client import TelegramManagerClient, get_message_file_attribute
  File "C:\Users\usert\pipx\venvs\telegram-upload\Lib\site-packages\telegram_upload\client\telegram_manager_client.py", line 6, in <module>
    from distutils.version import StrictVersion
ModuleNotFoundError: No module named 'distutils'
```

Documentation about distutils [deprecation and removal](https://docs.python.org/3/library/distutils.html)